### PR TITLE
Generation of the "fallback" response

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -17,7 +17,16 @@ final class Dispatcher implements StackInterface
 {
     /** @var ServerMiddlewareInterface[]|ClientMiddlewareInterface[] */
     private $queue = [];
+    private $fallbackHandler;
 
+    /**
+    * Generation of the "fallback" response is delegated to the application developer
+    */
+    public function __construct(MiddlewareInterface $fallbackHandler)
+    {
+        $this->fallbackHandler = $fallbackHandler;
+    }
+    
     /**
      * @inheritdoc
      * @return static
@@ -79,7 +88,7 @@ final class Dispatcher implements StackInterface
         $frame = new CallableBasedDelegate(function (RequestInterface $request) use (&$queue, &$frame) {
             $middleware = array_shift($queue);
             if (null === $middleware) {
-                throw new QueueIsEmpty();
+                return $this->fallbackHandler->handle($request);
             }
 
             return $middleware->process($request, $frame);


### PR DESCRIPTION
Generation of the "fallback" response is delegated to the application developer
 This allows the developer to determine whether that should be a "404 Not Found" condition, a default page, etc.
@see https://github.com/weierophinney/fig-standards/blob/162ea8b212e24790c6eea6453f0221935f55fbeb/proposed/http-handlers/request-handlers-meta.md

$fallbackHandler = new NotFound;
$dispatcher = (new Dispatcher($fallbackHandler))
    ->withMiddleware(new Dummy)
    ->withMiddleware(new Router);


class Router implements MiddlewareInterface
{
    public function process(Request $request, $frame)
    {
        if ($this->router->hasMatch()) {
            return new HtmlResponse('Hello World !');
        }
        return $frame->handle($request);  // fallback handler 404 not found
    }
}